### PR TITLE
Fix the complete option

### DIFF
--- a/spectragram.js
+++ b/spectragram.js
@@ -124,7 +124,9 @@ if (typeof Object.create !== 'function') {
 				}
             }
 			
-			self.options.complete.call(self);
+			if (typeof self.options.complete === 'function') {
+				self.options.complete.call(self);
+			}
         }
     };
 	


### PR DESCRIPTION
Fix the complete option to stop these errors: 'Uncaught TypeError: Cannot call method 'call' of null'
