### PR TITLE
Bug fix for title truncation when it contains single quotes. Also added ...

### DIFF
--- a/spectragram.js
+++ b/spectragram.js
@@ -120,7 +120,23 @@ if (typeof Object.create !== 'function') {
 					else {
 						size = results.data[i].images.standard_resolution.url;
 					}
-					self.$elem.append($(self.options.wrapEachWith).append("<a title='" + results.data[i].caption.text + "' target='_blank' href='" + results.data[i].link + "'><img src='" + size + "'></img></a>"));
+
+					var titleIMG;
+					// Skip if the caption is empty.
+					if ( results.data[i].caption != null ) {
+						/**
+						* 1. First it creates a dummy element <span/>
+						* 2. And then puts the caption inside the element created previously.
+						* 3. Extracts the html caption (this allows html codes to be included).
+						* 4. Lastly, the most important part, create the Title attribute using double quotes
+						* to enclose the text. This fixes the bug when the caption retrieved from Instagram 
+						* includes single quotes which breaks the Title attribute.
+						*/
+						titleIMG = 'title="' + $('<span/>').text(results.data[i].caption.text).html() +'"';
+					}
+
+					// Now concatenate the titleIMG generated.
+					self.$elem.append($(self.options.wrapEachWith).append("<a " + titleIMG + " target='_blank' href='" + results.data[i].link + "'><img src='" + size + "'></img></a>"));
 				}
             }
 			


### PR DESCRIPTION
The bug exists when the caption retrieved from Instagram contains single quotes. The title attribute gets truncated.

For example:
![screen shot 2014-01-13 at 12 42 21 am](https://f.cloud.github.com/assets/1410147/1896599/8a877226-7ba9-11e3-920c-dacb97bf079a.png)
After the fix:
![screen shot 2014-01-13 at 12 50 20 am](https://f.cloud.github.com/assets/1410147/1896602/c26eb1ea-7ba9-11e3-92bd-18cee209845a.png)

Also notice the heart symbol being recognised which is also included in this fix.