### PR TITLE
removed misleading brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ In order to use the plugin you need to register an application at [Instagram Dev
 
 ```javascript
 jQuery.fn.spectragram.accessData = {
-	accessToken: '[your-instagram-access-token]',
-	clientID: '[your-instagram-application-clientID]'
+	accessToken: 'your-instagram-access-token',
+	clientID: 'your-instagram-application-clientID'
 };
 ```
 3. Call **spectagram** function on the container element and pass it your query:


### PR DESCRIPTION
removed square brackets at the init code example, since they might make some people think that codes should be enclosed in them, while they shouldn't
