### PR TITLE
Only request media for exact match on getUserFeed

### DIFF
--- a/spectragram.js
+++ b/spectragram.js
@@ -56,7 +56,12 @@ if (typeof Object.create !== 'function') {
 
 				self.fetch(getData).done(function ( results ) {
 					if(results.data.length){
-						self.getRecentMedia(results.data[0].id);
+						// only request media for exact match, otherwise 400 error
+						for (var length = results.data.length, i = 0; i < length; i++) {
+				        		if ( results.data[i].username === self.options.query) {
+				            			self.getRecentMedia(results.data[i].id);
+				           		}
+						}
 					}else{
 						$.error('Spectagram.js - Error: the username ' + self.options.query + ' does not exist.');
 					};


### PR DESCRIPTION
When requesting media from getUserFeed, if multiple results are obtained, a 400 error is obtained for those that are not an exact match.