### PR TITLE
Add files property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.1",
   "description": "An easy jQuery plugin for Instagram API to fetch and display user, popular or tags photo feeds inside your web application or site.",
   "main": "spectragram.js",
+  "files": [
+    "spectragram.js"
+  ],
   "author": "Adrian Quevedo <npm@adrianquevedo.com> (http://adrianquevedo.com/)",
   "homepage": "http://spectragram.js.org",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An easy jQuery plugin for Instagram API to fetch and display user, popular or tags photo feeds inside your web application or site.",
   "main": "spectragram.js",
   "files": [
-    "spectragram.js"
+    "spectragram.js",
+    "spectragram.min.js"
   ],
   "author": "Adrian Quevedo <npm@adrianquevedo.com> (http://adrianquevedo.com/)",
   "homepage": "http://spectragram.js.org",


### PR DESCRIPTION
Changes proposed in this Pull Request:
- Add `files` property to `package.json`, and only specify `spectragram.js` in the array. This will result in only `spectragram.js` being distributed via npm (along with the essentials such as `README.md` and `LICENSE`), reducing the distribution size from 275kb to 5kb.

@adrianengine
